### PR TITLE
Fix typo in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
             <button type="button" class="close" data-dismiss="modal">&times;</button>
           </div>
           <div class="modal-body">
-            <p>You won't be able to retore data</p>
+            <p>You won't be able to restore data</p>
           </div>
           <div class="modal-footer">
             <button id="deleteTime" type="button" class="btn btn-outline-danger" data-dismiss="modal">Yes</button>


### PR DESCRIPTION
## Summary
- correct `retore` typo in the delete modal message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841a7d62b80832bbf90ecfaea8dfc23