### PR TITLE
Fix comment about cache memory

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -89,6 +89,6 @@ function duplicate() {
 
   //in this step I should run onload method too, to reload clone DOM elements
 
-  //I can try to save some data to ceche memory
+  // I can try to save some data to cache memory
 }
 


### PR DESCRIPTION
## Summary
- fix typo in JavaScript comment to properly mention cache memory

## Testing
- `grep -n "cache memory" -n scripts/scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_6841a7fae96c832ba2b2db5b2d2e088b