### PR TITLE
Add CLI menu for running app or tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ This is a small web application that combines a timer with a simple task list. Y
 - Create separate timers for multiple tasks in a to‑do list
 
 Open `index.html` in a browser to try it out.
+
+## Command-line usage
+
+Run the `run.sh` script to install dependencies and open an interactive menu.
+
+```
+./run.sh
+```
+
+Menu options allow you to start a local server for the application or run the test suite.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Ensure npm dependencies are installed
+npm install
+
+# Display menu
+PS3="Select an option: "
+options=("Start application" "Run tests" "Quit")
+select opt in "${options[@]}"; do
+  case $REPLY in
+    1)
+      echo "Starting application on http://localhost:8080"
+      npx http-server -p 8080 &
+      server_pid=$!
+      read -p "Press Enter to stop the server..." dummy
+      kill $server_pid
+      break
+      ;;
+    2)
+      echo "Running tests..."
+      npm test
+      ;;
+    3)
+      echo "Exiting..."
+      break
+      ;;
+    *)
+      echo "Invalid option";
+      ;;
+  esac
+done


### PR DESCRIPTION
## Summary
- add `run.sh` bash script with interactive menu for starting the app or running tests
- document how to use the new script in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841ab56ef0c832b9b9fd5ec852cadf3