### PR TITLE
Improve stopwatch timer and add modern styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,9 @@
     <div class="container">
 
       <div id="section" class="text-center">
-        <h1>
-          <time>00:00:00</time>
-        </h1>
+          <h1>
+            <time id="display">00:00:00</time>
+          </h1>
         <button id="start" class="btn btn-outline-success">start</button>
         <button id="stop" class="btn btn-outline-primary">stop</button>
         <a id="clear" href="#myModal" class="btn btn-outline-danger" data-toggle="modal" data-target="#myModal">clear</a>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,15 +11,15 @@
 
 //
 
-var h1 = document.getElementsByTagName("h1")[0],
-  start = document.getElementById("start"),
-  stop = document.getElementById("stop"),
-  clear = document.getElementById("clear"),
+var timeDisplay = document.getElementById("display"),
+  startBtn = document.getElementById("start"),
+  stopBtn = document.getElementById("stop"),
+  clearBtn = document.getElementById("deleteTime"),
   plus = document.getElementById("plus"),
   seconds = 0,
   minutes = 0,
   hours = 0,
-  t,
+  timerInterval,
   addNote,
   deleteNote,
   openNote;
@@ -29,7 +29,7 @@ window.addEventListener("unload", function (start) {
 });
 
 
-function add() {
+function tick() {
   seconds++;
   if (seconds >= 60) {
     seconds = 0;
@@ -40,38 +40,43 @@ function add() {
     }
   }
 
-  h1.textContent =
+  timeDisplay.textContent =
     (hours ? (hours > 9 ? hours : "0" + hours) : "00") +
     ":" +
     (minutes ? (minutes > 9 ? minutes : "0" + minutes) : "00") +
     ":" +
     (seconds > 9 ? seconds : "0" + seconds);
-
-  timer();
 }
 
-
-function timer() {
-  t = setTimeout(add, 1000);
+function startTimer() {
+  if (!timerInterval) {
+    timerInterval = setInterval(tick, 1000);
+    timeDisplay.classList.add("running");
+  }
 }
+
+function stopTimer() {
+  clearInterval(timerInterval);
+  timerInterval = null;
+  timeDisplay.classList.remove("running");
+}
+
 
 /* Start button */
 
-start.onclick = timer;
+startBtn.onclick = startTimer;
 
 /* Stop button */
-stop.onclick = function () {
-  clearTimeout(t);
-};
-
+stopBtn.onclick = stopTimer;
 
 /* Clear button */
 
-deleteTime.onclick = function () {
-  h1.textContent = "00:00:00";
+clearBtn.onclick = function () {
+  stopTimer();
   seconds = 0;
   minutes = 0;
   hours = 0;
+  timeDisplay.textContent = "00:00:00";
 };
 
 var original = document.getElementById("duplicater");

--- a/style/style.css
+++ b/style/style.css
@@ -1,5 +1,11 @@
 body {
   padding: 20px;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
 }
 
 #plus {
@@ -8,16 +14,26 @@ body {
 }
 
 #section {
-  box-shadow: 0 0 5px;
-  opacity: 0.5;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
+  opacity: 0.9;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
 }
 
 #section:hover {
   opacity: 1;
+  transform: scale(1.02);
 }
 
 .btn {
   margin: 10px;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
 }
 
 .title,
@@ -43,4 +59,20 @@ label:hover {
   font-family: "Montserrat", sans-serif;
   font-size: 20px;
   margin: 5px;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.running {
+  animation: pulse 1s infinite;
 }


### PR DESCRIPTION
## Summary
- prevent multiple timers from running and allow stopping
- use animated styling for the timer and buttons
- add gradient page background
- mark time element with id `display`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841ad0e4dd8832bbf68a83f65c46408