### PR TITLE
Fix add timer functionality with new UI enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,29 +20,28 @@
 </head>
 
 <body>
-  <div id="duplicater">
-    <div class="container">
+  <div id="timers">
+    <div id="duplicater" class="timer-card">
+      <div class="container">
+        <div class="text-center">
+            <h1>
+              <time class="display">00:00:00</time>
+            </h1>
+          <button class="start btn btn-outline-success">start</button>
+          <button class="stop btn btn-outline-primary">stop</button>
+          <button class="clear btn btn-outline-danger" data-toggle="modal" data-target="#myModal">clear</button>
+          <br>
 
-      <div id="section" class="text-center">
-          <h1>
-            <time id="display">00:00:00</time>
-          </h1>
-        <button id="start" class="btn btn-outline-success">start</button>
-        <button id="stop" class="btn btn-outline-primary">stop</button>
-        <a id="clear" href="#myModal" class="btn btn-outline-danger" data-toggle="modal" data-target="#myModal">clear</a>
-        <br>
-
-        <label class="pull-left">Title</label>
-        <input class="clickedit" type="text" />
-        <div class="clearfix"></div>
+          <label class="pull-left">Title</label>
+          <input class="clickedit" type="text" />
+          <div class="clearfix"></div>
+        </div>
       </div>
-
-
+      <br>
     </div>
-    <br>
   </div>
-  <div class="text-left">
-    <button id="plus" class="fas fa-plus fa-1x" onclick="duplicate()"></button>
+  <div class="text-left mt-2">
+    <button id="plus" class="btn btn-success">Add timer</button>
   </div>
   <button id="refreshButton" onclick="loadScript('scripts.js')">
     Refresh script

--- a/scripts/__tests__/scripts.test.js
+++ b/scripts/__tests__/scripts.test.js
@@ -4,12 +4,14 @@ let consoleError;
 beforeEach(() => {
   consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
   document.body.innerHTML = `
-    <div id="duplicater"></div>
-    <h1></h1>
-    <button id="start"></button>
-    <button id="stop"></button>
-    <div id="clear"></div>
-    <div id="deleteTime"></div>
+    <div id="duplicater">
+      <time class="display"></time>
+      <button class="start"></button>
+      <button class="stop"></button>
+      <button class="clear"></button>
+    </div>
+    <button id="deleteTime"></button>
+    <button id="plus"></button>
   `;
   jest.resetModules();
   duplicateFn = require('../scripts.js').duplicate;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,102 +1,103 @@
-// Dodac petle do while, albo for a najlepiej if i warunek, on load
+class Timer {
+  constructor(root) {
+    this.root = root;
+    this.display = root.querySelector('.display');
+    this.startBtn = root.querySelector('.start');
+    this.stopBtn = root.querySelector('.stop');
+    this.clearBtn = root.querySelector('.clear');
+    this.seconds = 0;
+    this.minutes = 0;
+    this.hours = 0;
+    this.timerInterval = null;
+    this.registerEvents();
+  }
 
-//skanowanie w tle..
-
-//local storage in json format
-
-//Najlepiej bylo by uzyc ajax do wymiany danych w tle, by nie przeladowywac scryptu
-
-
-
-
-//
-
-var timeDisplay = document.getElementById("display"),
-  startBtn = document.getElementById("start"),
-  stopBtn = document.getElementById("stop"),
-  clearBtn = document.getElementById("deleteTime"),
-  plus = document.getElementById("plus"),
-  seconds = 0,
-  minutes = 0,
-  hours = 0,
-  timerInterval,
-  addNote,
-  deleteNote,
-  openNote;
-
-window.addEventListener("unload", function (start) {
-  console.log("I am the 3rd one.");
-});
-
-
-function tick() {
-  seconds++;
-  if (seconds >= 60) {
-    seconds = 0;
-    minutes++;
-    if (minutes >= 60) {
-      minutes = 0;
-      hours++;
+  registerEvents() {
+    this.startBtn.addEventListener('click', () => this.start());
+    this.stopBtn.addEventListener('click', () => this.stop());
+    if (this.clearBtn) {
+      this.clearBtn.addEventListener('click', () => {
+        currentTimer = this;
+      });
     }
   }
 
-  timeDisplay.textContent =
-    (hours ? (hours > 9 ? hours : "0" + hours) : "00") +
-    ":" +
-    (minutes ? (minutes > 9 ? minutes : "0" + minutes) : "00") +
-    ":" +
-    (seconds > 9 ? seconds : "0" + seconds);
-}
+  tick() {
+    this.seconds++;
+    if (this.seconds >= 60) {
+      this.seconds = 0;
+      this.minutes++;
+      if (this.minutes >= 60) {
+        this.minutes = 0;
+        this.hours++;
+      }
+    }
+    this.updateDisplay();
+  }
 
-function startTimer() {
-  if (!timerInterval) {
-    timerInterval = setInterval(tick, 1000);
-    timeDisplay.classList.add("running");
+  updateDisplay() {
+    this.display.textContent =
+      (this.hours > 9 ? this.hours : '0' + this.hours) + ':' +
+      (this.minutes > 9 ? this.minutes : '0' + this.minutes) + ':' +
+      (this.seconds > 9 ? this.seconds : '0' + this.seconds);
+  }
+
+  start() {
+    if (!this.timerInterval) {
+      this.timerInterval = setInterval(() => this.tick(), 1000);
+      this.display.classList.add('running');
+    }
+  }
+
+  stop() {
+    clearInterval(this.timerInterval);
+    this.timerInterval = null;
+    this.display.classList.remove('running');
+  }
+
+  reset() {
+    this.stop();
+    this.seconds = 0;
+    this.minutes = 0;
+    this.hours = 0;
+    this.updateDisplay();
   }
 }
 
-function stopTimer() {
-  clearInterval(timerInterval);
-  timerInterval = null;
-  timeDisplay.classList.remove("running");
+let timers = [];
+let currentTimer = null;
+
+function initTimerElements() {
+  const original = document.getElementById('duplicater');
+  if (original) {
+    timers.push(new Timer(original));
+  }
+  const deleteBtn = document.getElementById('deleteTime');
+  if (deleteBtn) {
+    deleteBtn.addEventListener('click', () => {
+      if (currentTimer) {
+        currentTimer.reset();
+        currentTimer = null;
+      }
+    });
+  }
+  const plus = document.getElementById('plus');
+  if (plus) {
+    plus.addEventListener('click', duplicate);
+  }
 }
 
-
-/* Start button */
-
-startBtn.onclick = startTimer;
-
-/* Stop button */
-stopBtn.onclick = stopTimer;
-
-/* Clear button */
-
-clearBtn.onclick = function () {
-  stopTimer();
-  seconds = 0;
-  minutes = 0;
-  hours = 0;
-  timeDisplay.textContent = "00:00:00";
-};
-
-var original = document.getElementById("duplicater");
+document.addEventListener('DOMContentLoaded', initTimerElements);
 
 function duplicate() {
-  var clone = original.cloneNode(true); // "deep" clone so I can try to do it in diffrent way
-  clone.id = "duplicater";
-  // or clone.id = ""; if the divs don't need an ID
+  const original = document.getElementById('duplicater');
+  if (!original) return;
+  const clone = original.cloneNode(true);
+  clone.id = 'duplicater';
   original.parentNode.appendChild(clone);
-
-
-  window.location = window.location.href;
-
-  window.location.reload(true);
-
-  //in this step I should run onload method too, to reload clone DOM elements
-
-  // I can try to save some data to cache memory
+  timers.push(new Timer(clone));
 }
 
-
-if (typeof module !== "undefined") { module.exports = { duplicate }; }
-
+if (typeof module !== 'undefined') {
+  module.exports = { duplicate, Timer };
+}

--- a/style/style.css
+++ b/style/style.css
@@ -8,21 +8,35 @@ body {
   justify-content: flex-start;
 }
 
+
 #plus {
-  padding: 20px;
-  color: black;
+  background: #28a745;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 50px;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-#section {
+#plus:hover {
+  transform: scale(1.05);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.16);
+}
+
+.timer-card {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
-  opacity: 0.9;
+  opacity: 0.95;
   transition: transform 0.3s ease, opacity 0.3s ease;
   background: #fff;
   border-radius: 8px;
   padding: 20px;
+  margin-bottom: 20px;
+  animation: fadeIn 0.4s ease;
 }
 
-#section:hover {
+.timer-card:hover {
   opacity: 1;
   transform: scale(1.02);
 }
@@ -69,6 +83,17 @@ label:hover {
     transform: scale(1.1);
   }
   100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
     transform: scale(1);
   }
 }


### PR DESCRIPTION
## Summary
- allow creating multiple timers without page reload
- convert timer elements to classes for easy duplication
- add Timer class to manage independent stopwatch state
- modernize button styles and add animations
- update tests for new DOM structure

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841aedc7868832b89fda8800a329907