### PR TITLE
Add timer editing handlers and tests

### DIFF
--- a/scripts/__tests__/scripts.test.js
+++ b/scripts/__tests__/scripts.test.js
@@ -1,5 +1,6 @@
 let duplicateFn;
 let Timer;
+let attachEditHandlers;
 let consoleError;
 
 beforeEach(() => {
@@ -11,11 +12,15 @@ beforeEach(() => {
       <button class="start"></button>
       <button class="stop"></button>
       <button class="clear"></button>
+      <label>Title</label>
+      <input class="clickedit" type="text" />
     </div>
     <button id="deleteTime"></button>
     <button id="plus"></button>
   `;
-  ({ duplicate: duplicateFn, Timer } = require('../scripts.js'));
+  ({ duplicate: duplicateFn, Timer, attachEditHandlers } = require('../scripts.js'));
+  const root = document.getElementById('duplicater');
+  attachEditHandlers(root);
 });
 
 afterEach(() => {
@@ -80,4 +85,35 @@ test('plus button duplicates a timer after DOMContentLoaded', () => {
   expect(document.querySelectorAll('#duplicater').length).toBe(1);
   document.getElementById('plus').click();
   expect(document.querySelectorAll('#duplicater').length).toBe(2);
+});
+
+test('buttons operate correctly on a duplicated timer', () => {
+  duplicateFn();
+  const clone = document.querySelectorAll('#duplicater')[1];
+  attachEditHandlers(clone);
+  const timer = new Timer(clone);
+  timer.startBtn.click();
+  jest.advanceTimersByTime(2000);
+  expect(timer.display.textContent).toBe('00:00:02');
+  timer.stopBtn.click();
+  jest.advanceTimersByTime(2000);
+  expect(timer.display.textContent).toBe('00:00:02');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  const del = document.getElementById('deleteTime');
+  timer.clearBtn.click();
+  del.click();
+  expect(timer.display.textContent).toBe('00:00:00');
+});
+
+test('editing label works on newly created timer', () => {
+  duplicateFn();
+  const clone = document.querySelectorAll('#duplicater')[1];
+  attachEditHandlers(clone);
+  const label = clone.querySelector('label');
+  const input = clone.querySelector('.clickedit');
+  label.click();
+  input.value = 'New task';
+  input.dispatchEvent(new Event('blur'));
+  expect(label.textContent).toBe('New task');
+  expect(input.style.display).toBe('none');
 });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -64,12 +64,39 @@ class Timer {
   }
 }
 
+function attachEditHandlers(container) {
+  const input = container.querySelector('.clickedit');
+  const label = input ? input.previousElementSibling : null;
+  if (!input || !label) return;
+  input.style.display = 'none';
+
+  function endEdit() {
+    label.textContent = input.value === '' ? 'Click me and enter some text' : input.value;
+    input.style.display = 'none';
+    label.style.display = '';
+  }
+
+  input.addEventListener('blur', endEdit);
+  input.addEventListener('keyup', e => {
+    if (e.key === 'Tab') {
+      endEdit();
+    }
+  });
+
+  label.addEventListener('click', () => {
+    label.style.display = 'none';
+    input.style.display = '';
+    input.focus();
+  });
+}
+
 let timers = [];
 let currentTimer = null;
 
 function initTimerElements() {
   const original = document.getElementById('duplicater');
   if (original) {
+    attachEditHandlers(original);
     timers.push(new Timer(original));
   }
   const deleteBtn = document.getElementById('deleteTime');
@@ -95,9 +122,10 @@ function duplicate() {
   const clone = original.cloneNode(true);
   clone.id = 'duplicater';
   original.parentNode.appendChild(clone);
+  attachEditHandlers(clone);
   timers.push(new Timer(clone));
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = { duplicate, Timer };
+  module.exports = { duplicate, Timer, attachEditHandlers };
 }


### PR DESCRIPTION
## Summary
- enable editing labels for timers via new `attachEditHandlers`
- hook editing handlers when timers are created or duplicated
- extend test coverage for duplicated timer controls and label editing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841bc111138832ba16d6f94b1697f89